### PR TITLE
Fix: Add explicit reference to Microsoft.PowerShell.Commands.Diagnostics

### DIFF
--- a/AICommandPrompt/AICommandPrompt.csproj
+++ b/AICommandPrompt/AICommandPrompt.csproj
@@ -8,5 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Prism.DryIoc" Version="8.1.97" />
     <PackageReference Include="System.Management.Automation" Version="7.2.18" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.2.18" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The application was failing to load the Microsoft.PowerShell.Diagnostics snap-in due to a missing Microsoft.PowerShell.Commands.Diagnostics.dll in the output directory.

This change adds an explicit PackageReference to
Microsoft.PowerShell.Commands.Diagnostics version 7.2.18 (matching the System.Management.Automation version) in the AICommandPrompt.csproj file. This ensures that the .NET SDK correctly includes the necessary runtime assets, resolving the PSSnapInException.