### PR TITLE
Fix: Add explicit reference to Microsoft.PowerShell.ConsoleHost

### DIFF
--- a/AICommandPrompt/AICommandPrompt.csproj
+++ b/AICommandPrompt/AICommandPrompt.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Prism.DryIoc" Version="8.1.97" />
     <PackageReference Include="System.Management.Automation" Version="7.2.18" />
     <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.2.18" />
+    <PackageReference Include="Microsoft.PowerShell.ConsoleHost" Version="7.2.18" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Following the previous fix for Microsoft.PowerShell.Commands.Diagnostics, the application subsequently failed to load the Microsoft.PowerShell.Host snap-in due to a missing Microsoft.PowerShell.ConsoleHost.dll.

This change adds an explicit PackageReference to
Microsoft.PowerShell.ConsoleHost version 7.2.18 (matching the System.Management.Automation version) in the AICommandPrompt.csproj file. This should ensure that the .NET SDK correctly includes this necessary runtime asset, resolving the PSSnapInException for this component.