### PR TITLE
Fix: Correct DelegateCommand invocation in MainWindow

### DIFF
--- a/AICommandPrompt/Views/MainWindow.xaml.cs
+++ b/AICommandPrompt/Views/MainWindow.xaml.cs
@@ -76,9 +76,9 @@ namespace AICommandPrompt.Views
                     if (currentViewModel != null)
                     {
                         // Check if the SendMessageCommand can be executed
-                        if (currentViewModel.SendMessageCommand.CanExecute(null)) // Pass null for parameter if command doesn't expect one
+                        if (currentViewModel.SendMessageCommand.CanExecute())
                         {
-                            currentViewModel.SendMessageCommand.Execute(null); // Pass null for parameter
+                            currentViewModel.SendMessageCommand.Execute();
                         }
                     }
                     // Mark the event as handled to prevent TextBox from processing Enter (i.e., inserting a newline)


### PR DESCRIPTION
Corrected calls to SendMessageCommand.CanExecute and Execute in the ChatMessageInputTextBox_PreviewKeyDown method within MainWindow.xaml.cs.

The methods were being called with a `null` argument, but the DelegateCommand `SendMessageCommand` is not generic and expects no arguments. This caused CS1501 build errors ("No overload for method '...' takes 1 arguments").

The explicit `null` arguments have been removed, so the calls are now `CanExecute()` and `Execute()`, which should resolve the build failure.