### PR TITLE
Fix: Remove invalid FontSize attribute from MainWindow.xaml

### DIFF
--- a/AICommandPrompt/Views/MainWindow.xaml
+++ b/AICommandPrompt/Views/MainWindow.xaml
@@ -44,7 +44,7 @@
                             <StackPanel MaxWidth="600"> <!-- Limit message width -->
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="{Binding Sender}" FontWeight="Bold"/>
-                                    <TextBlock Text="{Binding Timestamp, StringFormat=' - HH:mm:ss'}" FontSize="10" Foreground="Gray" Margin="5,0,0,0"/>
+                                    <TextBlock Text="{Binding Timestamp, StringFormat=' - HH:mm:ss'}" Foreground="Gray" Margin="5,0,0,0"/>
                                 </StackPanel>
                                 <TextBlock Text="{Binding Text}" TextWrapping="Wrap" Margin="0,3,0,0">
                                     <TextBlock.Style>


### PR DESCRIPTION
I removed the FontSize attribute from a TextBlock element in AICommandPrompt/Views/MainWindow.xaml that was causing a build failure (MC3072). The attribute was found on line 47.